### PR TITLE
Proposed changes: Metada on session start action

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -4,7 +4,6 @@
 # See this guide on how to implement these action:
 # https://rasa.com/docs/rasa/core/actions/#custom-actions/
 
-
 # This is a simple example for a custom action which utters "Hello World!"
 
 from typing import Any, Text, Dict, List
@@ -13,28 +12,29 @@ from rasa_sdk import Action, Tracker
 from rasa_sdk.executor import CollectingDispatcher
 
 
-
 def extract_metadata_from_tracker(tracker):
     events = tracker.current_state()['events']
     user_events = []
     for e in events:
-        if e['event'] == 'user':
+        if e['event'] in ['user', 'session_started']:
             user_events.append(e)
 
-    return user_events[-1]['metadata']
+        if len(user_events) > 0:
+            return user_events[-1]['metadata']
+        return None
+
 
 class ActionHelloWorld(Action):
 
     def name(self) -> Text:
         return "action_hello_world"
 
-    def run(self, dispatcher: CollectingDispatcher,
+    def run(self,
+            dispatcher: CollectingDispatcher,
             tracker: Tracker,
-            domain: Dict[Text, Any]) -> List[Dict[Text, Any]]:
+            domain: Dict[Text, Any]
+            ) -> List[Dict[Text, Any]]:
 
-        metadata=extract_metadata_from_tracker(tracker)
-        
-        print("MetaData: ",metadata)
+        metadata = extract_metadata_from_tracker(tracker)
         dispatcher.utter_message(text="Hello World!")
-
         return []


### PR DESCRIPTION
Linked to issue:
https://github.com/RasaHQ/rasa/issues/5574

The default action 'action_session_start' wasn't
able to receive the metadata from the message sent,
RASA when initiating a new session it sends a blank
tracker with no information whatsoever, ignoring
the metadata into the message.

Adjusted to receive the event sessionStart from tracker events
and with it the metadata from the message.